### PR TITLE
Remove canvas DOM element on destroy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 _book
+dist/
 

--- a/lib/DiaporamaRenderingCanvas/index.js
+++ b/lib/DiaporamaRenderingCanvas/index.js
@@ -72,7 +72,12 @@ DiaporamaRenderingCanvas.prototype = {
     for (var t in this._textures) {
       this._textures[t].dispose();
     }
-    this._post.dispose();
+    if (this._post) {
+      this._post.dispose();
+    }
+    if (this._canvas) {
+      this._container.removeChild(this._canvas);
+    }
     this._fbos = null;
     this._canvas = null;
     this._canvases = null;

--- a/test/01.js
+++ b/test/01.js
@@ -29,5 +29,10 @@ function (t, api, diaporama) {
     t.equal(diaporama.loop, false);
     t.equal(diaporama.autoplay, true);
     t.equal(diaporama.paused, true, "After some time, the diaporama should pause because loop is disabled.");
+
+    diaporama.destroy();
+    var div = document.getElementById('container');
+    var hasChildren = div.children && div.children.length > 0
+    t.equal(hasChildren, false, "Diaporama should remove its canvas from the DOM");
   });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -13,6 +13,7 @@ function destroy () {
 function create (data, options) {
   destroy();
   var div = document.createElement("div");
+  div.id = 'container';
   div.style.position = "fixed";
   div.style.top = 0;
   div.style.left = 0;


### PR DESCRIPTION
Hello,

This small change makes the library more friendly for single-page apps that may destroy and re-create instances of diaporama.

[test_output.txt](https://github.com/gre/diaporama/files/1709184/test_output.txt)
